### PR TITLE
Feature/adding assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Related Changelog
 
+## 1.2.0 - [Unreleased]
+
+### Added
+
+- Added support for displaying relations on Asset edit pages.
+
 ## 1.1.6 - 2020-03-30
 
 ### Updated

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/related",
     "description": "A simple plugin that adds a widget within the Craft CP page sidebar, allowing you to quickly and easily access related entries.",
     "type": "craft-plugin",
-    "version": "1.1.6",
+    "version": "1.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/Related.php
+++ b/src/Related.php
@@ -134,9 +134,11 @@ class Related extends Plugin
     {
         $sections = Craft::$app->getSections()->getAllSections();
         $categories = Craft::$app->getCategories()->getAllGroups();
+        $assetVolumes = Craft::$app->getVolumes()->getAllVolumes();
 
         $optionsSections = [];
         $optionsCategories = [];
+        $optionsAssetVolumes = [];
 
         foreach ($sections as $id => $section) {
             $optionsSections[$section->handle] = $section->name;
@@ -148,12 +150,18 @@ class Related extends Plugin
         }
         $optionsCategories['nobodyIsGoingToCallACategoryThis'] = 'None';
 
+        foreach ($assetVolumes as $id => $volume) {
+            $optionsAssetVolumes[$volume->handle] = $volume->name;
+        }
+        $optionsAssetVolumes['nobodyIsGoingToCallAnAssetVolumeThis'] = 'None';
+
         return Craft::$app->view->renderTemplate(
             'related/settings',
             [
                 'settings' => $this->getSettings(),
                 'optionsSections' => $optionsSections,
                 'optionsCategories' => $optionsCategories,
+                'optionsAssetVolumes' => $optionsAssetVolumes,
             ]
         );
     }

--- a/src/Related.php
+++ b/src/Related.php
@@ -97,6 +97,8 @@ class Related extends Plugin
                         || preg_match('/^\/.+\/categories\//', Craft::$app->getRequest()->getUrl())
                         || preg_match('/^\/.+\/users\//', Craft::$app->getRequest()->getUrl())
                         || preg_match('/^\/.+\/myaccount/', Craft::$app->getRequest()->getUrl())
+                        || preg_match('/^\/.+\/assets\//', Craft::$app->getRequest()->getUrl())
+
                     )
                 ) {
                     $url = Craft::$app->assetManager->getPublishedUrl('@wrav/related/assetbundles/related/dist/js/Related.js', true);

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -62,7 +62,20 @@ class DefaultController extends Controller
         $data = Craft::$app->request->getQueryParams();
         $allowedSections = Related::getInstance()->getSettings()->allowedSections;
         $allowedCategories = Related::getInstance()->getSettings()->allowedCategories;
+        $allowedAssetVolumes = Related::getInstance()->getSettings()->allowedAssetVolumes;
         $shouldFetch = false;
+
+        if(Craft::$app->elements->getElementTypeById($data['id']) === 'craft\elements\Asset') {
+            $asset = Craft::$app->elements->getElementById($data['id']);
+            $volumeId = $asset->volume->id;
+            if(!$allowedAssetVolumes){
+                $shouldFetch = true;
+            } else if (is_array($allowedAssetVolumes)) {
+                if(in_array($volumeId, $allowedAssetVolumes)) {
+                    $shouldFetch = true;
+                }
+            }
+        }
 
         if (!empty($data['sectionId'])) {
             if (!$allowedSections) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -44,4 +44,9 @@ class Settings extends Model
      */
     public $allowedCategories;
 
+    /**
+     * @var string
+     */
+    public $allowedAssetVolumes;
+
 }

--- a/src/services/RelatedService.php
+++ b/src/services/RelatedService.php
@@ -12,6 +12,7 @@ namespace wrav\related\services;
 
 use craft\base\Element;
 use craft\db\Query;
+use craft\elements\Asset;
 use craft\elements\Category;
 use craft\elements\Entry;
 use craft\elements\User;

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -34,3 +34,14 @@
         options: optionsCategories,
     }) }}
 {% endif %}
+
+{% if optionsAssetVolumes|length %}
+    {{ forms.multiselectField({
+        label: "Allowed Asset Volumes"|t,
+        instructions: "Choose which asset volumes the relation widget will show on. Leave blank for all volumes"|t,
+        id: 'allowedAssetVolumes',
+        name: 'allowedAssetVolumes',
+        values: settings['allowedAssetVolumes'],
+        options: optionsAssetVolumes,
+    }) }}
+{% endif %}


### PR DESCRIPTION
This PR adds support for viewing relations on Asset edit pages. Additionally, the plugin's settings page now includes a multi-select form for Asset Volumes.