### PR TITLE
Swaps the URL used for the globe icon to the frontend URL

### DIFF
--- a/src/templates/_modal.twig
+++ b/src/templates/_modal.twig
@@ -18,6 +18,7 @@
                             {% set title = item.title ?? item.name ?? item.username ?? null %}
                             {% set status = item.status %}
                             {% set cpEditUrl = item.cpEditUrl ?? '#' %}
+                            {% set frontendUrl = item.url ?? '#' %}
 
                             <tr>
                                 <td>
@@ -40,8 +41,8 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% if cpEditUrl %}
-                                        <a href="{{ cpEditUrl }}" rel="noopener" target="_blank" data-icon="world"
+                                    {% if frontendUrl %}
+                                        <a href="{{ frontendUrl }}" rel="noopener" target="_blank" data-icon="world"
                                            title="Visit webpage"></a>
                                     {% endif %}
                                 </td>


### PR DESCRIPTION
In the modal there is a column with a globe icon. Through the rest of the Craft UI this icon links to the frontend. In this plugin, however, it links to the backend. It's a confusing experience for our editors (and probably others). 

I was hoping to standardize this since clicking the title of the entry already links to the backend (as is standard). 